### PR TITLE
fix: 适配 doc 3.4.x 获取侧边栏

### DIFF
--- a/src/DocLib/Render.php
+++ b/src/DocLib/Render.php
@@ -31,7 +31,7 @@ class Render
     {
         $file = ltrim($file,'/');
         $page = $this->parserMdFile($file,$language);
-        $sideBar = $this->parserMdFile('sidebar.md',$language);
+        $sideBar = $this->parserMdFile('sideBar.md',$language);
         $headHtml = $this->config2HtmlTag($page->getConfig());
         $data = [
             'sidebar'=>$sideBar->getHtml(),


### PR DESCRIPTION
fix: 适配 doc 3.4.x 获取侧边栏